### PR TITLE
Wells/swebench dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,5 @@ multiswebench/README.md
 multiswebench/clean_config.json
 logs/
 gemini-2.0-flash.test*.json
+
+dev/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,7 @@
-[submodule "swe-bench"]
-	path = swe-bench
-	url = git@github.com:princeton-nlp/SWE-bench.git
+# [submodule "swe-bench"]
+# 	path = swe-bench
+# 	url = git@github.com:princeton-nlp/SWE-bench.git
+
+[submodule "SWE-bench"]
+	path = SWE-bench
+	url = git@github.com:seal-research/SWE-bench.git

--- a/CodeArena_grading.py
+++ b/CodeArena_grading.py
@@ -17,7 +17,8 @@ from swebench.harness.constants import (
     TestStatus,
 )
 from utils import merge_and_unpack
-from swebench.harness.test_spec import TestSpec
+# from swebench.harness.test_spec import TestSpec
+from swebench.harness.test_spec import test_spec as TestSpec
 from swebench.harness.log_parsers import MAP_REPO_TO_PARSER
 
 class TestedStatus(Enum):

--- a/CodeArena_test_spec.py
+++ b/CodeArena_test_spec.py
@@ -25,7 +25,11 @@ from swebench.harness.dockerfiles import (
     get_dockerfile_env,
     get_dockerfile_instance,
 )
-from swebench.harness.utils import (
+# from swebench.harness.utils import (
+#     get_requirements,
+#     get_environment_yml
+# )
+from swebench.harness.test_spec.python import (
     get_requirements,
     get_environment_yml
 )

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ CodeArena is currently set up to work with a specific swebench version which can
 ```bash
 git clone https://github.com/seal-research/SWE-bench.git
 cd SWE-bench
-pip install -e .
+# pip install -e .
+pip install .
 ```
 
 

--- a/codearena.py
+++ b/codearena.py
@@ -375,6 +375,8 @@ def main():
     parser.add_argument("--language", type=str, choices=['auto', 'python', 'java'],
                         default='auto', help="Language for StyleReview, auto for automatic detection")
 
+    parser.add_argument("--use_apptainer", type=str2bool, default=False, help="run with docker or apptainer")
+
     args = parser.parse_args()
 
     # Collect active flags
@@ -419,7 +421,8 @@ def main():
             swebench.versioning.constants.MAP_REPO_TO_VERSION_PATTERNS[instance_repo] = REPO_DATA[instance_repo]["MAP_REPO_TO_VERSION_PATTERNS"]
             swebench.harness.constants.MAP_REPO_VERSION_TO_SPECS[instance_repo] = REPO_DATA[instance_repo]["MAP_REPO_VERSION_TO_SPECS"]
 
-            from swebench.harness.log_parsers import parse_log_pytest, parse_log_pytest_options, parse_log_pytest_v2
+            # from swebench.harness.log_parsers import parse_log_pytest, parse_log_pytest_options, parse_log_pytest_v2
+            from swebench.harness.log_parsers.python import parse_log_pytest, parse_log_pytest_options, parse_log_pytest_v2
             if "MAP_REPO_TO_PARSER" in REPO_DATA[instance_repo]:
                 repo_log_parser = eval(REPO_DATA[instance_repo]["MAP_REPO_TO_PARSER"])
             else:
@@ -443,7 +446,13 @@ def main():
             clean=args.clean,
             open_file_limit=args.open_file_limit,
             run_id=args.run_id,
-            timeout=args.timeout
+            timeout=args.timeout,
+            # namespace=,
+            # rewrite_reports=,
+            # modal=,
+            # instance_image_tag=,
+            # report_dir=,
+            use_apptainer=args.use_apptainer
         )
 
     if "TestGeneration" in active_flags:
@@ -477,7 +486,13 @@ def main():
             clean=args.clean,
             open_file_limit=args.open_file_limit,
             run_id=args.run_id,
-            timeout=args.timeout
+            timeout=args.timeout,
+            # namespace=,
+            # rewrite_reports=,
+            # modal=,
+            # instance_image_tag=,
+            # report_dir=,
+            use_apptainer=args.use_apptainer
         )
 
     if "CodeMigration" in active_flags:

--- a/monkeypatched_swebench.py
+++ b/monkeypatched_swebench.py
@@ -14,7 +14,8 @@ def monkey_patch_swebench():
         swebench.versioning.constants.MAP_REPO_TO_VERSION_PATTERNS[instance_repo] = REPO_DATA[instance_repo]["MAP_REPO_TO_VERSION_PATTERNS"]
         swebench.harness.constants.MAP_REPO_VERSION_TO_SPECS[instance_repo] = REPO_DATA[instance_repo]["MAP_REPO_VERSION_TO_SPECS"]
 
-        from swebench.harness.log_parsers import parse_log_pytest
+        # from swebench.harness.log_parsers import parse_log_pytest
+        from swebench.harness.log_parsers.python import parse_log_pytest
         if "MAP_REPO_TO_PARSER" in REPO_DATA[instance_repo]:
             repo_log_parser = eval(REPO_DATA[instance_repo]["MAP_REPO_TO_PARSER"])
         else:


### PR DESCRIPTION
For running with the new swebench, there are some functions called path that have been changed. 

readme: pip install . without -e when installing swebench, so all files will be installed in site-packages

.gitmodules: point to correct swebench version URL

codearena, monkeypatched_swebench, CodeArena_test_spec, CodeArena_grading: some swebench function paths have been changed